### PR TITLE
Fix the goreleaser which creates GitHub releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,7 @@
+---
+project_name: example-label-checker-consumer
+build:
+  skip: true
+release:
+  github:
+  prerelease: auto


### PR DESCRIPTION
Forgot to include the `.goreleaser.yml` file on the previous commit,
with an instruction to skip the build of the binary (this repo does not
have any Go binary to build right now, so the release process fails
if the building is not skipped).