### PR TITLE
Add languagetool check via reviewdog

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -25,3 +25,16 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
+
+  languagetool:
+    name: runner / languagetool
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-languagetool@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-check
+          patterns: |
+            **/*.md
+          language: en


### PR DESCRIPTION
https://github.com/reviewdog/action-languagetool

https://languagetool.org/

https://github.com/languagetool-org/languagetool

Use en locale for languagetool checks

Use `en` as it does not do spell checking, whereas if we use `en-gb`
`en-gb` then it flags errors for the US spelling of `LICENSE`
(which is what it should do).
As LICENSE is the conventional name for the licence file, we
don't want it to be reported.

Our spell checking is done by misspell (which we have set to allow UK
or US variants e.g. colour and color), so we don't want languagetool
to do spell checking anyway.